### PR TITLE
Add duplicate gif detection when loading new gifs

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -20,7 +20,8 @@ const GifsModel = mongoose.model(
   new mongoose.Schema({
     id: String,
     name: String,
-    tags: [String]
+    tags: [String],
+    checksum: String
   })
 );
 const GifCacheModel = mongoose.model(
@@ -111,13 +112,20 @@ export const FindGifsByNameRegex = async (regex: string): Promise<any[]> => {
   return query.find();
 };
 
-export const AddGif = async (file: { id: any; name: any; tags: any }) => {
+export const AddGif = async (file: {
+  id: any;
+  name: any;
+  tags: any;
+  checksum: string;
+}) => {
   let gif = new GifsModel();
   gif.id = file.id;
   // @ts-ignore
   gif.name = file.name;
   // @ts-ignore
   gif.tags = file.tags;
+  // @ts-ignore
+  gif.checksum = file.checksum;
   return gif.save();
 };
 
@@ -142,6 +150,30 @@ export const RenameGif = async (oldName: any, newName: any) => {
   // Prioritize gifs with a matching name over gifs with a matching id, in case a file name is a duplicate of some id.
   return (
     (await query({ name: oldName })) || ((await query({ id: oldName })) as any)
+  );
+};
+
+export const FindGifByChecksum = async (checksum: string) => {
+  if (!checksum) throw "Checksum missing!";
+  return await GifsModel.where({
+    checksum
+  }).findOne();
+};
+
+export const UpdateGifChecksum = async (id: string, checksum: string) => {
+  if (!checksum) throw "Checksum missing!";
+  // @ts-ignore
+  return await GifsModel.findOneAndUpdate(
+    { id: id },
+    {
+      $set: {
+        checksum: checksum
+      }
+    },
+    {
+      useFindAndModify: false,
+      new: true
+    }
   );
 };
 

--- a/src/drive/auth.ts
+++ b/src/drive/auth.ts
@@ -1,5 +1,5 @@
 //https://console.developers.google.com/apis/credentials/consent?project=beaming-team-148423
-import googleAuth from "google-auth-library";
+import { OAuth2Client } from "google-auth-library";
 import { ParsedQs } from "qs";
 import { SetCache } from "../database";
 import setting, { settingsGoogle } from "../settings";
@@ -23,8 +23,7 @@ function GetOauth2Client(callback: {
   const clientSecret = credentials.installed.client_secret;
   const clientId = credentials.installed.client_id;
   const redirectUrl = credentials.installed.redirect_uris[0];
-  const auth = new (googleAuth as any)();
-  const oauth2Client = new auth.OAuth2(clientId, clientSecret, redirectUrl);
+  const oauth2Client = new OAuth2Client(clientId, clientSecret, redirectUrl);
   callback({ success: true, message: oauth2Client });
 }
 

--- a/src/drive/dal.ts
+++ b/src/drive/dal.ts
@@ -35,30 +35,9 @@ const filesToTags = (files: filesToTagsInterface[]) => {
   for (let i = 0; i < files.length; i++) {
     const file = files[i];
     if (!file.name) continue;
-    file.name = file.name.toLowerCase();
+    file.name = file.name.toLowerCase().replace(/ /g, "_");
     file.tags = getTagsFromFileName(file.name);
   }
-  return files;
-};
-
-export const listAllFiles = async () => {
-  const files = [] as drive_v3.Schema$FileList[];
-  let nextPageToken = null;
-  let page = 1;
-  do {
-    const fetchPageResult = await fetchPage(undefined, {
-      q: "mimeType = 'image/gif' and '0BwoBPbVKwbI9TUdFSG0yRjh5UTQ' in parents"
-    });
-    if (!fetchPageResult.files) return;
-    nextPageToken = fetchPageResult.nextPageToken;
-    files.push.apply(files, filesToTags(fetchPageResult.files));
-    files.push.apply(files, fetchPageResult.files);
-    page = page + 1;
-  } while (
-    // while (nextPageToken);
-    nextPageToken &&
-    page < 3
-  );
   return files;
 };
 
@@ -72,7 +51,7 @@ const fetchPage = async (
     auth: auth
   });
   return new Promise<drive_v3.Schema$FileList>((resolve) => {
-    query.fields = "nextPageToken, files(id, name)";
+    query.fields = "nextPageToken, files(id, name, md5Checksum)";
     query.spaces = "drive";
     query.pageToken = pageToken;
     // console.log("getting ", query, " from Google drive")


### PR DESCRIPTION
-  Add new gifs with a checksum field from Drive
-  When adding new gif, look up if checksum already exists and skip if it does
-  When processing gifs, if an existing gif entry for a file ID is found, set its checksum if not set yet
-  Fix drive auth
-  Increase DB test timeout to 15s
-  Replace spaces in filenames to underscores