### PR TITLE
Add a simple web page to bulk download gifs for adooter packages

### DIFF
--- a/.github/workflows/privatesettings.prod.json
+++ b/.github/workflows/privatesettings.prod.json
@@ -33,6 +33,10 @@
 		],
 		"renamegif": [
 			"328194320601710593"
+		],
+		"bulkdownload": [
+			"328194320601710593"
 		]
-	}
+	},
+	"ClientUrl": "http://gifs.kitten.academy"
 }

--- a/client/download.html
+++ b/client/download.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="UTF-8">
+</head>
+
+<body>
+	<div id="state"></div>
+	<script type="module">
+		import { downloadZip } from "https://cdn.jsdelivr.net/npm/client-zip@2.3.0/index.min.js"
+		const chunkSize = 50;
+		function GetQueryStringParams(sParam) {
+			var sPageURL = window.location.search.substring(1);
+			var sURLVariables = sPageURL.split('&');
+			for (var i = 0; i < sURLVariables.length; i++) {
+				var sParameterName = sURLVariables[i].split('=');
+				if (sParameterName[0] == sParam) {
+					return sParameterName[1];
+				}
+			}
+		}
+
+		async function fetchGif(url) {
+			const response = await fetch(url);
+			return response.arrayBuffer();
+		}
+
+		var chunks = [];
+		var key;
+		var container;
+
+		async function init() {
+			key = GetQueryStringParams('key');
+			container = document.getElementById("state");
+			renderState();
+			const data = await fetch("/bulkdownload/?key=" + key).then(x => x.json());
+			for (let i = 0; i < data.length; i += chunkSize) {
+				const chunk = {
+					data: data.slice(i, i + chunkSize),
+					prepare: true
+				}
+				chunks.push(chunk);
+			}
+			renderState();
+			window.prepareChunk = prepareChunk;
+			window.downloadChunk = downloadChunk;
+		}
+
+		async function prepareChunk(chunk) {
+			chunks[chunk].prepare = false;
+			chunks[chunk].files = [];
+			const data = chunks[chunk].data;
+			for (let i = 0; i < data.length; i++) {
+				chunks[chunk].status = `Downloading gif ${i + 1}/${data.length}`;
+				renderState();
+				let gif = await fetchGif(data[i].url);
+				chunks[chunk].files.push({ name: data[i].filename, input: gif });
+			}
+			chunks[chunk].status = `Generating zip`;
+			renderState();
+			const blob = await downloadZip(
+				chunks[chunk].files
+			).blob()
+			chunks[chunk].blob = blob;
+			chunks[chunk].files = null;
+			renderState();
+		}
+
+		function downloadChunk(chunk) {
+			const link = document.createElement("a")
+			link.href = URL.createObjectURL(chunks[chunk].blob);
+			link.download = `${key}_${chunk}.zip`;
+			link.click()
+			chunks[chunk].blob = null;
+			chunks[chunk].done = true;
+			renderState();
+		}
+
+		function renderState() {
+			if (!chunks.length) {
+				container.innerHTML = 'loading data';
+				return;
+			}
+			let content = "";
+			for (let i = 0; i < chunks.length; i++) {
+				content += `Chunk ${i}: `;
+				const chunk = chunks[i];
+				if (chunk.done) content += 'done';
+				else if (chunk.blob) content += `<a href = "javascript:downloadChunk(${i})">download</a>`;
+				else if (chunk.prepare) content += `<a href="javascript:prepareChunk(${i})">prepare</a>`;
+				else content += `foo ${chunk.status}`;
+				content += "</br></br>";
+			}
+			container.innerHTML = content;
+		}
+
+		try {
+			await init();
+		} catch (e) {
+			container.innerText = "Initialization failed (is your key still valid?):" + e.toString();
+		}
+	</script>
+</body>
+
+</html>

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import randomgif from "./drive/randomgif";
 import { FindGifsByExactTags, init } from "./database";
 import { connectToDiscord } from "./discord/bot";
 import { pollForGifsInDrive } from "./files/gifs";
+import { getEntry } from "./files/bulkdownload";
 
 let app = express();
 let server = http.createServer(app);
@@ -32,6 +33,9 @@ app.get("/tags", async (req, res) => {
     (req.query.text as string).split(" ")
   );
   res.json(files);
+});
+app.get("/bulkdownload", function (req, res) {
+  res.json(getEntry(req.query.key as string));
 });
 app.use("/", express.static(__dirname + "/../client"));
 app.get("/gifs/*", function (req, res) {

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -13,11 +13,13 @@ import catfacts from "./module/catfacts";
 import {
   generateGifsCsvAttachment,
   generateRenameGifsCsvAttachment,
-  parseBulkRenameAttachment
+  parseBulkRenameAttachment,
+  parseCsvToRows
 } from "./csv";
 import jokes from "./module/jokes";
 import https from "https";
 import { deleteFile } from "../s3/s3";
+import { addEntry } from "../files/bulkdownload";
 const client = new Discord.Client({
   restRequestTimeout: 60000,
   intents: [
@@ -269,6 +271,18 @@ const HandleBotCommand = async (
       content: `Found ${gifs.length} gif(s) matching \`${payload.command}\``,
       files: [attachment]
     });
+  } else if (payload.moduleName == "bulkdownload") {
+    if (!payload.attachments.length) {
+      await payload.discordMessage.reply(
+        "Usage: `!bulkdownload [with a two column csv attachment, consisting of ids and names]"
+      );
+      return;
+    }
+    const rows = await parseCsvToRows(payload.attachments[0]);
+    const key = addEntry(rows);
+    await payload.discordMessage.reply(
+      setting("ClientUrl") + "/download.html?key=" + key
+    );
   } else if (payload.moduleName == "deletegif") {
     const id = payload.command;
     if (!id) {

--- a/src/discord/csv.ts
+++ b/src/discord/csv.ts
@@ -13,11 +13,7 @@ interface GifRename {
 export const parseBulkRenameAttachment = async (
   messageAttachment: MessageAttachment
 ) => {
-  if (messageAttachment.size > 100 * 1024) throw "File too big";
-  const response = await fetch(messageAttachment.url);
-  if (!response.ok) throw "Failed to load attachment";
-  const text = await response.text();
-  const rows = csvParse(text, { relaxColumnCount: true });
+  const rows = await parseCsvToRows(messageAttachment);
   const renames = rows.map(parseRow);
   const findDuplicate = (a: string[]) =>
     [...a].sort().find((elem, i, arr) => arr[i + 1] === elem);
@@ -34,6 +30,16 @@ export const parseBulkRenameAttachment = async (
     throw `A new name and an old name match: \`${duplicate}\``;
   }
   return renames;
+};
+
+export const parseCsvToRows = async (
+  messageAttachment: MessageAttachment
+): Promise<string[][]> => {
+  if (messageAttachment.size > 100 * 1024) throw "File too big";
+  const response = await fetch(messageAttachment.url);
+  if (!response.ok) throw "Failed to load attachment";
+  const text = await response.text();
+  return csvParse(text, { relaxColumnCount: true });
 };
 
 const parseRow = (row: string[], index: number): GifRename => {

--- a/src/files/bulkdownload.spec.ts
+++ b/src/files/bulkdownload.spec.ts
@@ -1,0 +1,25 @@
+import { getURL } from "../cloudFront/cloudFront";
+import { addEntry, getEntry } from "./bulkdownload";
+
+describe("bulkdownload", () => {
+  test("should store csv", () => {
+    const data = [
+      ["id1", "filename_1.gif"],
+      ["id2", "filename_2.gif"],
+      ["id2", "filename_2.gif"],
+      []
+    ];
+    const key = addEntry(data);
+
+    expect(getEntry(key)).toEqual([
+      {
+        filename: "filename_1.gif",
+        url: getURL("id1") + ".gif"
+      },
+      {
+        filename: "filename_2.gif",
+        url: getURL("id2") + ".gif"
+      }
+    ]);
+  });
+});

--- a/src/files/bulkdownload.ts
+++ b/src/files/bulkdownload.ts
@@ -1,0 +1,49 @@
+import { createHash } from "crypto";
+import { getURL } from "../cloudFront/cloudFront";
+const maxCacheCount = 20;
+const cache: { key: string; data: IGifRow[] }[] = [];
+function hash(csv: string[][]): string {
+  const md5sum = createHash("md5");
+  md5sum.update(JSON.stringify(csv));
+  return md5sum.digest("hex");
+}
+
+function addCache(key: string, data: IGifRow[]): void {
+  cache.push({ key, data });
+  if (cache.length > maxCacheCount) cache.shift();
+}
+
+function uniqBy<T, R>(arr: T[], key: (elem: T) => R): T[] {
+  const seen = new Set();
+  return arr.filter((item) => {
+    const k = key(item);
+    return seen.has(k) ? false : seen.add(k);
+  });
+}
+
+export function addEntry(csv: string[][]): string {
+  const filtered = uniqBy(
+    csv.filter((row) => row.length === 2),
+    (row) => row[1]
+  );
+  const key = hash(filtered);
+  addCache(
+    key,
+    filtered.map((row) => ({
+      url: getURL(row[0]) + ".gif",
+      filename: row[1]
+    }))
+  );
+  return key;
+}
+
+export function getEntry(key: string): IGifRow[] {
+  const match = cache.filter((row) => row.key === key);
+  if (!match.length) throw "not found";
+  return match[0].data;
+}
+
+export interface IGifRow {
+  url: string;
+  filename: string;
+}

--- a/src/privatesettings.example.json
+++ b/src/privatesettings.example.json
@@ -33,6 +33,10 @@
 		],
 		"renamegif": [
 			""
-		]
-	}
+		],
+		"bulkdownload": [
+			""
+		],
+	},
+	"ClientUrl": "http://gifs.kitten.academy"
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -39,7 +39,9 @@ export interface settings {
     bulkfindgifs: string[];
     deletegif: string[];
     renamegif: string[];
+    bulkdownload: string[];
   };
+  ClientUrl: string;
 }
 export interface settingsGoogle {
   installed: {


### PR DESCRIPTION
How it works:
- Create a csv with gifs to download (e.g. with !bulkfindgifs)
- Pass the csv to !bulkdownload
- Open the linked page, and start downloading the zips one by one

Zips are created in chunks of 50 to avoid exploding the tab's memory usage. Most adooter packages should be less than 300 gifs so this shouldn't be too expensive for S3/CloudFront. To be used by admins, with care...